### PR TITLE
Allow for implicit interface implementation of ObjectWithAppStatus.

### DIFF
--- a/test/api/v1alpha1/test_types.go
+++ b/test/api/v1alpha1/test_types.go
@@ -94,7 +94,7 @@ func (test *Test) Default() {
 
 var _ reconciler.ObjectWithAppStatus = &Test{}
 
-func (t *Test) GetStatus() reconciler.AppStatus {
+func (t *Test) GetStatus() any {
 	return &t.Status
 }
 


### PR DESCRIPTION
This allows for interface implementation (ObjectWithAppStatus) without having to import basereconciler in the cosumer API package.

/kind fix
/priority important-soon
/assign